### PR TITLE
Custom Image Sizes

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+# Issue Title :memo:
+
+Add a description of the issue. Titles should be followed with
+an emoji outlining the issue type, matching git commits. Use emoji
+codes from [gitmoji](https://gitmoji.carloscuesta.me/).
+
+## Possible Solutions
+
+- A list of ideas?
+
+## Fix
+
+A description of the final fix for the issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+# Title
+
+Add a description of changes and link to any open issues this change addresses. List any dependencies or breaking
+changes. Increment version and commit updated changelog after merging into master.
+
+Fixes #(issue)
+
+## Type of change
+
+Please delete irrelevant options:
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Requires a documentation update
+- [ ] Refactoring
+
+## Testing Description
+
+Please describe the tests that you ran to verify your changes. Provide instructions if they differ from usual tests.
+Please also list any relevant details for your test configuration.
+
+## Documentation update
+
+- [ ] Changelog has been updated.
+
+Specify changes to documentation if required for this change.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Full docs for routes are found here.
 |-------|--------|-------------|
 | /api/media/links | POST | Store a link |
 | /api/media/links/:id | GET | Get all links for an item of media |
+| /api/media/:id | GET | Get an image from the server. To get an image you must pass your access token as a url query `token=<YOUR_TOKEN>`. You can also pass a `size` query to specify the image size, between `1024` and `100` pixels. |
 
 ## Generic Resources
 If `x` is the generic resource, then the following routes apply. Routes are in the plural form of the word.

--- a/web/routes/api/MediaRouter.ts
+++ b/web/routes/api/MediaRouter.ts
@@ -86,9 +86,27 @@ export class MediaRouter
    */
   async show(req: Request, res: Response, next: NextFunction): Promise<void | Response> {
     const mediaId: Schema.Types.ObjectId = req.params.id;
+    const rsize: string = req.query.size;
+    let size: number;
+    const defaultSize: number = 600;
+    const maxSize: number = 1024;
+    const minSize: number = 100;
     const mediaController: MediaController = new MediaController();
     let user: IUser;
     let media: IMedia;
+
+    // Sanitize size.
+    if (rsize) {
+      if (/\D+/g.test(rsize)) {
+        size = defaultSize;
+      } else {
+        size = parseInt(rsize, 10);
+        if (size > maxSize) size = maxSize;
+        if (size < minSize) size = minSize;
+      }
+    } else {
+      size = defaultSize;
+    }
 
     if (res.locals.error) {
       return next(new Error(`${res.locals.error}`));
@@ -108,7 +126,7 @@ export class MediaRouter
 
     let data: any;
     try {
-      data = await mediaController.getMediaFromS3(media);
+      data = await mediaController.getMediaFromS3(media, size);
     } catch (e) {
       return next(new Error('500'));
     }


### PR DESCRIPTION
# Custom Image Sizes :sparkles:

Clients can request images in any size. Minimum size is 100, maximum is 1024. All sizes are cached in remote storage. Sizes are specified as a URL query, for example:
```
https://ongoingness-api.openlab.ncl.ac.uk/api/media/:id?token=<YOUR_TOKEN>&size=512
```

Fixes #11

## Type of change
- [X] New feature
- [X] Requires a documentation update

## Testing Description
Passes old tests, no new ones written.

## Documentation update
- [X] Update README 
